### PR TITLE
chore: update api-gateway name

### DIFF
--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           git clone https://github.com/instill-ai/${{ inputs.component }}.git
           cd ${{ inputs.component }}
-          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=9080
+          make integration-test API_GATEWAY_MODEL_HOST=localhost API_GATEWAY_MODEL_PORT=9080
 
       - name: Uppercase component name
         if: inputs.target == 'release'
@@ -80,4 +80,4 @@ jobs:
         run: |
           git clone -b v$COMPONENT_VERSION https://github.com/instill-ai/${{ inputs.component }}.git
           cd ${{ inputs.component }}
-          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=9080
+          make integration-test API_GATEWAY_MODEL_HOST=localhost API_GATEWAY_MODEL_PORT=9080

--- a/Makefile
+++ b/Makefile
@@ -223,8 +223,8 @@ integration-test-latest:			## Run integration test on the latest model
 		--network instill-network \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
 		${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
-			/bin/bash -c 'cd model-backend && make integration-test API_GATEWAY_HOST=${API_GATEWAY_MODEL_HOST} API_GATEWAY_PORT=${API_GATEWAY_MODEL_PORT}' && \
-			/bin/bash -c 'cd controller-model && make integration-test API_GATEWAY_HOST=${API_GATEWAY_MODEL_HOST} API_GATEWAY_PORT=${API_GATEWAY_MODEL_PORT}' \
+			/bin/bash -c 'cd model-backend && make integration-test API_GATEWAY_MODEL_HOST=${API_GATEWAY_MODEL_HOST} API_GATEWAY_MODEL_PORT=${API_GATEWAY_MODEL_PORT}' && \
+			/bin/bash -c 'cd controller-model && make integration-test API_GATEWAY_MODEL_HOST=${API_GATEWAY_MODEL_HOST} API_GATEWAY_MODEL_PORT=${API_GATEWAY_MODEL_PORT}' \
 		"
 	@make down
 
@@ -248,8 +248,8 @@ integration-test-release:			## Run integration test on the release model
 		--network instill-network \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-release \
 		${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/bash -c " \
-			/bin/bash -c 'cd model-backend && make integration-test API_GATEWAY_HOST=${API_GATEWAY_MODEL_HOST} API_GATEWAY_PORT=${API_GATEWAY_MODEL_PORT}' && \
-			/bin/bash -c 'cd controller-model && make integration-test API_GATEWAY_HOST=${API_GATEWAY_MODEL_HOST} API_GATEWAY_PORT=${API_GATEWAY_MODEL_PORT}' \
+			/bin/bash -c 'cd model-backend && make integration-test API_GATEWAY_MODEL_HOST=${API_GATEWAY_MODEL_HOST} API_GATEWAY_MODEL_PORT=${API_GATEWAY_MODEL_PORT}' && \
+			/bin/bash -c 'cd controller-model && make integration-test API_GATEWAY_MODEL_HOST=${API_GATEWAY_MODEL_HOST} API_GATEWAY_MODEL_PORT=${API_GATEWAY_MODEL_PORT}' \
 		"
 	@make down
 
@@ -284,13 +284,13 @@ helm-integration-test-latest:                       ## Run integration test on t
 	@while ! nc -vz localhost ${API_GATEWAY_MODEL_PORT} > /dev/null 2>&1; do sleep 1; done
 ifeq ($(UNAME_S),Darwin)
 	@docker run -it --rm -p ${API_GATEWAY_MODEL_PORT}:${API_GATEWAY_MODEL_PORT} --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-latest ${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
-			/bin/bash -c 'cd model-backend && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=${API_GATEWAY_MODEL_PORT}' && \
-			/bin/bash -c 'cd controller-model && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=${API_GATEWAY_MODEL_PORT}' \
+			/bin/bash -c 'cd model-backend && make integration-test API_GATEWAY_MODEL_HOST=host.docker.internal API_GATEWAY_MODEL_PORT=${API_GATEWAY_MODEL_PORT}' && \
+			/bin/bash -c 'cd controller-model && make integration-test API_GATEWAY_MODEL_HOST=host.docker.internal API_GATEWAY_MODEL_PORT=${API_GATEWAY_MODEL_PORT}' \
 		"
 else ifeq ($(UNAME_S),Linux)
 	@docker run -it --rm --network host --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-latest ${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/bash -c " \
-			/bin/bash -c 'cd model-backend && make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=${API_GATEWAY_MODEL_PORT}' && \
-			/bin/bash -c 'cd controller-model && make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=${API_GATEWAY_MODEL_PORT}' \
+			/bin/bash -c 'cd model-backend && make integration-test API_GATEWAY_MODEL_HOST=localhost API_GATEWAY_MODEL_PORT=${API_GATEWAY_MODEL_PORT}' && \
+			/bin/bash -c 'cd controller-model && make integration-test API_GATEWAY_MODEL_HOST=localhost API_GATEWAY_MODEL_PORT=${API_GATEWAY_MODEL_PORT}' \
 		"
 endif
 	@helm uninstall model --namespace instill-ai
@@ -336,13 +336,13 @@ helm-integration-test-release:                       ## Run integration test on 
 	@while ! nc -vz localhost ${API_GATEWAY_MODEL_PORT} > /dev/null 2>&1; do sleep 1; done
 ifeq ($(UNAME_S),Darwin)
 	@docker run -it --rm -p ${API_GATEWAY_MODEL_PORT}:${API_GATEWAY_MODEL_PORT} --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-release ${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/bash -c " \
-			/bin/bash -c 'cd model-backend && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=${API_GATEWAY_MODEL_PORT}' && \
-			/bin/bash -c 'cd controller-model && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=${API_GATEWAY_MODEL_PORT}' \
+			/bin/bash -c 'cd model-backend && make integration-test API_GATEWAY_MODEL_HOST=host.docker.internal API_GATEWAY_MODEL_PORT=${API_GATEWAY_MODEL_PORT}' && \
+			/bin/bash -c 'cd controller-model && make integration-test API_GATEWAY_MODEL_HOST=host.docker.internal API_GATEWAY_MODEL_PORT=${API_GATEWAY_MODEL_PORT}' \
 		"
 else ifeq ($(UNAME_S),Linux)
 	@docker run -it --rm --network host --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-release ${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/bash -c " \
-			/bin/bash -c 'cd model-backend && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=${API_GATEWAY_MODEL_PORT}' && \
-			/bin/bash -c 'cd controller-model && make integration-test API_GATEWAY_HOST=host.docker.internal API_GATEWAY_PORT=${API_GATEWAY_MODEL_PORT}' \
+			/bin/bash -c 'cd model-backend && make integration-test API_GATEWAY_MODEL_HOST=host.docker.internal API_GATEWAY_MODEL_PORT=${API_GATEWAY_MODEL_PORT}' && \
+			/bin/bash -c 'cd controller-model && make integration-test API_GATEWAY_MODEL_HOST=host.docker.internal API_GATEWAY_MODEL_PORT=${API_GATEWAY_MODEL_PORT}' \
 		"
 endif
 	@helm uninstall model --namespace instill-ai


### PR DESCRIPTION
Because

- Some of our test-cases may be cross projects, we need to use different apigateway endpoints

This commit

- update integration test params
