### PR TITLE
chore(helm): add annotations for model-backend deployment

### DIFF
--- a/charts/model/templates/model-backend/deployment.yaml
+++ b/charts/model/templates/model-backend/deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     app.kubernetes.io/component: model-backend
   annotations:
     rollme: {{ randAlphaNum 5 | quote }}
+    {{- with .Values.modelBackend.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   strategy:
     type: {{ .Values.updateStrategy.type }}

--- a/charts/model/values.yaml
+++ b/charts/model/values.yaml
@@ -238,6 +238,8 @@ modelBackend:
     repository: instill/model-backend
     tag: 0.16.11-alpha
     pullPolicy: IfNotPresent
+  # -- Annotation for deployment
+  annotations: {}
   # -- The command names to be executed
   commandName:
     migration: model-backend-migrate


### PR DESCRIPTION
Because

- we need annotations for model-backend for secret updation.

This commit

- add annotations for model-backend deployment.
