### PR TITLE
chore(helm): enable flag for api-gateway

### DIFF
--- a/charts/model/templates/api-gateway-model/configmap.yaml
+++ b/charts/model/templates/api-gateway-model/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.apiGatewayModel.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -34,3 +35,4 @@ data:
     JAEGER_ENABLE={{ .Values.tags.observability }}
     JAEGER_HOST={{ template "base.jaeger" . }}
     JAEGER_PORT={{ template "base.jaeger.port" . }}
+{{- end }}

--- a/charts/model/templates/api-gateway-model/deployment.yaml
+++ b/charts/model/templates/api-gateway-model/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.apiGatewayModel.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -162,3 +163,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/model/templates/api-gateway-model/ingress.yaml
+++ b/charts/model/templates/api-gateway-model/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.expose.ingress.enabled }}
 {{- if eq .Values.expose.type "ingress" }}
 {{- $ingress := .Values.expose.ingress -}}
 {{- $tls := .Values.expose.tls -}}
@@ -63,4 +64,5 @@ spec:
     {{- if $ingress.hosts.apiGatewayModel }}
     host: {{ $ingress.hosts.apiGatewayModel }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/model/templates/api-gateway-model/service.yaml
+++ b/charts/model/templates/api-gateway-model/service.yaml
@@ -1,3 +1,4 @@
+{{- if or ( .Values.expose.clusterIP.enabled ) ( .Values.expose.nodePort.enabled ) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -87,3 +88,4 @@ spec:
   selector:
     {{- include "model.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: api-gateway-model
+{{- end }}

--- a/charts/model/values.yaml
+++ b/charts/model/values.yaml
@@ -47,6 +47,7 @@ expose:
       # "tls.key" - the private key
       secretName: ""
   ingress:
+    enabled: false
     hosts:
       apiGatewayModel: model.instill.tech
     # set to the type of ingress controller if it has specific requirements.
@@ -59,6 +60,7 @@ expose:
     # Annotations on the Ingress
     annotations: {}
   clusterIP:
+    enabled: false
     ports:
       # The service port api-gateway-model http listens on
       apiGatewayModelHttp:
@@ -69,6 +71,7 @@ expose:
     # Annotations on the ClusterIP service
     annotations: {}
   nodePort:
+    enabled: false
     ports:
       apiGatewayModelHttp:
         # The service port api-gateway-model http listens on
@@ -177,6 +180,7 @@ usage:
   host: usage.instill.tech
   port: 443
 apiGatewayModel:
+  enabled: false
   # -- The image of api-gateway
   image:
     repository: instill/api-gateway


### PR DESCRIPTION
Because

- We have to consolidate the api-gateway of vdp and model into the base for that we need to add enable flag.

This commit

- add enable flag into api-gateway-model