### PR TITLE
ci(Makefile): fix make stop and start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,12 +99,12 @@ endif
 
 .PHONY: logs
 logs:			## Tail all logs with -n 10
-	@docker compose logs --follow --tail=10
+	@EDITION= docker compose logs --follow --tail=10
 
 .PHONY: pull
 pull:			## Pull all service images
 	@docker inspect --type=image instill/tritonserver:${TRITON_SERVER_VERSION} >/dev/null 2>&1 || printf "\033[1;33mINFO:\033[0m This may take a while due to the enormous size of the Triton server image, but the image pulling process should be just a one-time effort.\n" && sleep 5
-	@docker compose pull
+	@EDITION= docker compose pull
 
 .PHONY: stop
 stop:			## Stop all components
@@ -125,6 +125,7 @@ start:			## Start all stopped components
 			/bin/sh -c 'cd /instill-ai/base && make start' \
 		"
 	@EDITION= docker compose start
+
 .PHONY: down
 down:			## Stop all services and remove all service containers and volumes
 	@docker rm -f ${CONTAINER_BUILD_NAME}-latest >/dev/null 2>&1
@@ -135,7 +136,7 @@ down:			## Stop all services and remove all service containers and volumes
 	@docker rm -f ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-release >/dev/null 2>&1
 	@docker rm -f ${CONTAINER_COMPOSE_NAME}-latest >/dev/null 2>&1
 	@docker rm -f ${CONTAINER_COMPOSE_NAME}-release >/dev/null 2>&1
-	@EDITION=NULL docker compose down -v
+	@EDITION= docker compose down -v
 	@if docker compose ls -q | grep -q "instill-base"; then \
 		if docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:latest >/dev/null 2>&1; then \
 			docker run --rm \
@@ -161,15 +162,11 @@ images:			## List all container images
 
 .PHONY: ps
 ps:				## List all service containers
-	@docker compose ps
+	@EDITION= docker compose ps
 
 .PHONY: top
 top:			## Display all running service processes
-	@docker compose top
-
-.PHONY: doc
-doc:						## Run Redoc for OpenAPI spec at http://localhost:3001
-	@docker compose up -d redoc_openapi
+	@EDITION= docker compose top
 
 .PHONY: build-latest
 build-latest:				## Build latest images for all model components

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       CFG_SERVER_MAXDATASIZE: ${MAX_DATA_SIZE}
       CFG_SERVER_ITMODE_ENABLED: ${ITMODE_ENABLED}
       CFG_SERVER_USAGE_ENABLED: ${USAGE_ENABLED}
-      CFG_SERVER_EDITION: ${EDITION:-local-ce:unknown}
+      CFG_SERVER_EDITION: ${EDITION}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
       CFG_DATABASE_PORT: ${POSTGRESQL_PORT}
       CFG_DATABASE_USERNAME: postgres
@@ -128,7 +128,7 @@ services:
     restart: unless-stopped
     environment:
       CFG_SERVER_DEBUG: "false"
-      CFG_SERVER_EDITION: ${EDITION:-local-ce:unknown}
+      CFG_SERVER_EDITION: ${EDITION}
       CFG_DATABASE_HOST: ${POSTGRESQL_HOST}
       CFG_DATABASE_PORT: ${POSTGRESQL_PORT}
       CFG_DATABASE_USERNAME: postgres
@@ -165,7 +165,7 @@ services:
       - triton_conda_env
 
   temporal_admin_tools:
-    container_name: ${TEMPORAL_HOST}-admin-tools
+    container_name: temporal-admin-tools
     image: ${TEMPORAL_ADMIN_TOOLS_IMAGE}:${TEMPORAL_ADMIN_TOOLS_VERSION}
     restart: on-failure
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     depends_on:
       model_backend_init:
         condition: service_completed_successfully
-      temporal_admin_tools:
+      temporal_admin_tools_model:
         condition: service_completed_successfully
 
   model_backend:
@@ -164,8 +164,8 @@ services:
     depends_on:
       - triton_conda_env
 
-  temporal_admin_tools:
-    container_name: temporal-admin-tools
+  temporal_admin_tools_model:
+    container_name: temporal-admin-tools-model
     image: ${TEMPORAL_ADMIN_TOOLS_IMAGE}:${TEMPORAL_ADMIN_TOOLS_VERSION}
     restart: on-failure
     environment:


### PR DESCRIPTION
Because

- `make stop/start` was broken due to the containers used in docker compose `depends_on` that are removed after spin-up

This commit

- remove `docker compose rm -f` in `make all/latest`
- remove `make rm` and `make restart` (no use case)
- set EDITION explicitly
- rename `temporal_admin_tools` to `temporal_admin_tools_model` to prevent conflict with VDP
