### PR TITLE
ci(workflow): update logic for integration test latest run on macos runner

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -108,7 +108,7 @@ jobs:
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
   helm-integration-test-latest-mac:
-    if: inputs.target == 'latest'
+    if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, model]
     steps:
       - name: Set up environment

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -103,7 +103,7 @@ jobs:
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
   integration-test-latest-mac:
-    if: inputs.target == 'latest'
+    if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, model]
     steps:
       - name: Set up environment


### PR DESCRIPTION
Because

- We have to update logic to run integration test workflow on macos runner

This commit

- update logic for integration test latest run on macos runner
