### PR TITLE
ci(Makefile): enhance Instill Core launch

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,13 @@
 # docker compose project name
 COMPOSE_PROJECT_NAME=instill-model
 
+# build from scratch or not at launch, which will build all sources from scrach. Default to false.
+BUILD=false
+
+# docker compose profiles to selectively launch components for developing the latest codebase of the specified component.
+# the value can be all, api-gateway, mgmt, pipeline, connector, controller-vdp, model, controller-model, or console.
+PROFILE=all
+
 # system-wise config path (all core, vdp, and model projects must use the same path)
 SYSTEM_CONFIG_PATH=${HOME}/.config/instill
 

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Launch Instill Model (release)
         run: |
-          make all EDITION=local-ce:test
+          make all BUILD=true EDITION=local-ce:test
 
       - name: List all docker containers
         run: |

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Launch Instill Model (latest)
         run: |
-          make latest PROFILE=all EDITION=local-ce:test
+          make latest BUILD=true PROFILE=all EDITION=local-ce:test
 
       - name: List all docker containers
         run: |

--- a/Makefile
+++ b/Makefile
@@ -43,23 +43,23 @@ HELM_RELEASE_NAME := model
 
 .PHONY: all
 all:			## Launch all services with their up-to-date release version
-	@make build-release
-	@if ! (docker compose ls -q | grep -q "instill-core"); then \
+	@if [ "${BUILD}" = "true" ]; then make build-release; fi
+	@if ! docker compose ls -q | grep -q "instill-core"; then \
 		export TMP_CONFIG_DIR=$(shell mktemp -d) && \
 		export SYSTEM_CONFIG_PATH=$(shell eval echo ${SYSTEM_CONFIG_PATH}) && \
 		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
 			-v $${SYSTEM_CONFIG_PATH}:$${SYSTEM_CONFIG_PATH} \
+			-e BUILD=${BUILD} \
 			--name ${CONTAINER_COMPOSE_NAME}-release \
 			${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
 				cp /instill-ai/core/.env $${TMP_CONFIG_DIR}/.env && \
 				cp /instill-ai/core/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
 				cp -r /instill-ai/core/configs/influxdb $${TMP_CONFIG_DIR} && \
-				/bin/sh -c 'cd /instill-ai/core && make all EDITION=$${EDITION:=local-ce} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}' && \
+				/bin/sh -c 'cd /instill-ai/core && make all BUILD=$${BUILD} PROJECT=core EDITION=$${EDITION:=local-ce} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}' && \
 				rm -rf $${TMP_CONFIG_DIR}/* \
-			" && \
-		rm -rf $${TMP_CONFIG_DIR}; \
+			" && rm -rf $${TMP_CONFIG_DIR}; \
 	fi
 ifeq (${NVIDIA_GPU_AVAILABLE}, true)
 	@docker inspect --type=image instill/tritonserver:${TRITON_SERVER_VERSION} >/dev/null 2>&1 || printf "\033[1;33mINFO:\033[0m This may take a while due to the enormous size of the Triton server image, but the image pulling process should be just a one-time effort.\n" && sleep 5
@@ -71,23 +71,24 @@ endif
 
 .PHONY: latest
 latest:			## Lunch all dependent services with their latest codebase
-	@make build-latest
-	@if ! (docker compose ls -q | grep -q "instill-core"); then \
+	@if [ "${BUILD}" = "true" ]; then make build-latest; fi
+	@if ! docker compose ls -q | grep -q "instill-core"; then \
 		export TMP_CONFIG_DIR=$(shell mktemp -d) && \
 		export SYSTEM_CONFIG_PATH=$(shell eval echo ${SYSTEM_CONFIG_PATH}) && \
 		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v $${TMP_CONFIG_DIR}:$${TMP_CONFIG_DIR} \
 			-v $${SYSTEM_CONFIG_PATH}:$${SYSTEM_CONFIG_PATH} \
+			-e BUILD=${BUILD} \
+			-e PROFILE=${PROFILE} \
 			--name ${CONTAINER_COMPOSE_NAME}-latest \
 			${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
 				cp /instill-ai/core/.env $${TMP_CONFIG_DIR}/.env && \
 				cp /instill-ai/core/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
 				cp -r /instill-ai/core/configs/influxdb $${TMP_CONFIG_DIR} && \
-				/bin/sh -c 'cd /instill-ai/core && make latest PROFILE=all EDITION=$${EDITION:=local-ce:latest} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH} OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}' && \
+				/bin/sh -c 'cd /instill-ai/core && make latest BUILD=$${BUILD} PROJECT=core PROFILE=$${PROFILE} EDITION=$${EDITION:=local-ce:latest} BUILD_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR} SYSTEM_CONFIG_PATH=$${SYSTEM_CONFIG_PATH} OBSERVE_CONFIG_DIR_PATH=$${TMP_CONFIG_DIR}' && \
 				rm -rf $${TMP_CONFIG_DIR}/* \
-			" && \
-		rm -rf $${TMP_CONFIG_DIR}; \
+			" && rm -rf $${TMP_CONFIG_DIR}; \
 	fi
 ifeq (${NVIDIA_GPU_AVAILABLE}, true)
 	@docker inspect --type=image instill/tritonserver:${TRITON_SERVER_VERSION} >/dev/null 2>&1 || printf "\033[1;33mINFO:\033[0m This may take a while due to the enormous size of the Triton server image, but the image pulling process should be just a one-time effort.\n" && sleep 5
@@ -137,24 +138,25 @@ down:			## Stop all services and remove all service containers and volumes
 	@docker rm -f ${CONTAINER_COMPOSE_NAME}-latest >/dev/null 2>&1
 	@docker rm -f ${CONTAINER_COMPOSE_NAME}-release >/dev/null 2>&1
 	@EDITION= docker compose down -v
-	@if docker compose ls -q | grep -q "instill-core"; then \
-		if docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:latest >/dev/null 2>&1; then \
-			docker run --rm \
-				-v /var/run/docker.sock:/var/run/docker.sock \
-				--name ${CONTAINER_COMPOSE_NAME} \
-				${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
-					/bin/sh -c 'cd /instill-ai/core && make down' \
-				"; \
-		elif docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:release >/dev/null 2>&1; then \
-			docker run --rm \
-				-v /var/run/docker.sock:/var/run/docker.sock \
-				--name ${CONTAINER_COMPOSE_NAME} \
-				${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
-					/bin/sh -c 'cd /instill-ai/core && make down' \
-				"; \
-		fi	\
+	@if [ "$$(docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:latest --format='yes')" = "yes" ]; then \
+		docker run --rm \
+			-v /var/run/docker.sock:/var/run/docker.sock \
+			--name ${CONTAINER_COMPOSE_NAME} \
+			${CONTAINER_COMPOSE_IMAGE_NAME}:latest /bin/sh -c " \
+				if [ \"$$( docker container inspect -f '{{.State.Status}}' core-dind 2>/dev/null)\" != \"running\" ]; then \
+					/bin/sh -c 'cd /instill-ai/core && make down'; \
+				fi \
+			"; \
+	elif [ "$$(docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:release --format='yes')" = "yes" ]; then \
+		docker run --rm \
+			-v /var/run/docker.sock:/var/run/docker.sock \
+			--name ${CONTAINER_COMPOSE_NAME} \
+			${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+				if [ \"$$( docker container inspect -f '{{.State.Status}}' core-dind 2>/dev/null)\" != \"running\" ]; then \
+					/bin/sh -c 'cd /instill-ai/core && make down'; \
+				fi \
+			"; \
 	fi
-
 
 .PHONY: images
 images:			## List all container images
@@ -213,7 +215,7 @@ build-release:				## Build release images for all model components
 
 .PHONY: integration-test-latest
 integration-test-latest:			## Run integration test on the latest model
-	@make latest PROFILE=all EDITION=local-ce:test ITMODE_ENABLED=true
+	@make latest BUILD=true PROFILE=all EDITION=local-ce:test ITMODE_ENABLED=true
 	@docker run --rm \
 		--network instill-network \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-latest \
@@ -225,7 +227,7 @@ integration-test-latest:			## Run integration test on the latest model
 
 .PHONY: integration-test-release
 integration-test-release:			## Run integration test on the release model
-	@make all EDITION=local-ce:test ITMODE_ENABLED=true
+	@make all BUILD=true EDITION=local-ce:test ITMODE_ENABLED=true
 	@docker run --rm \
 		--network instill-network \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-release \


### PR DESCRIPTION
Because

- the `core` repo is treated as the main Instill Core repo
- `make all/latest` now by default will launch all projects without building all components images from scratch
- `make all/latest PROJECT={core,vdp,model}` will launch the specified projects
- `make all/latest BUILD=true` will launch all projects and build all components from scratch
- `make down` will tear down everything in Instill Core
- `make all/latest {BUILD=true}` in the `vdp` and `model` repo will launch their dependent `core`
- `make down` in the `vdp` and `model` repo will tear down everything in Instill Core

This commit

- implement the above-mentioned logics
