### PR TITLE
ci(workflow): set time limit to workflow run

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -18,6 +18,7 @@ jobs:
   helm-integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
@@ -110,6 +111,7 @@ jobs:
   helm-integration-test-latest-mac:
     if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, model]
+    timeout-minutes: 20
     steps:
       - name: Set up environment
         run: |
@@ -235,6 +237,7 @@ jobs:
   helm-integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
@@ -341,6 +344,7 @@ jobs:
   helm-integration-test-release-mac:
     if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, model]
+    timeout-minutes: 20
     steps:
       - name: Set up environment
         run: |

--- a/.github/workflows/helm-integration-test-release.yml
+++ b/.github/workflows/helm-integration-test-release.yml
@@ -2,11 +2,6 @@ name: Helm Integration Test (release)
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - release-please--branches--main
-    tags:
-      - v*
 
 jobs:
   backend:

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -18,6 +18,7 @@ jobs:
   integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
@@ -105,7 +106,12 @@ jobs:
   integration-test-latest-mac:
     if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, model]
+    timeout-minutes: 10
     steps:
+      - name: remove existing docker container
+        run: |
+          docker rm -f $(docker ps -a -q)
+
       - name: Set up environment
         run: |
           brew install make
@@ -209,6 +215,7 @@ jobs:
   integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
@@ -304,6 +311,7 @@ jobs:
   integration-test-release-mac:
     if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, model]
+    timeout-minutes: 10
     steps:
       - name: Set up environment
         run: |

--- a/.github/workflows/integration-test-release.yml
+++ b/.github/workflows/integration-test-release.yml
@@ -2,11 +2,6 @@ name: Integration Test (release)
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - release-please--branches--main
-    tags:
-      - v*
 
 jobs:
   backend:

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -2,11 +2,6 @@ name: Make All
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - release-please--branches--main
-    tags:
-      - v*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}


### PR DESCRIPTION
Because

- We have to set time limit for each workflow run

This commit

- set time limit to workflow run
