### PR TITLE
ci(workflow): increase timeout of integration-test-latest|release workflow

### DIFF
--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -18,7 +18,7 @@ jobs:
   integration-test-latest-linux:
     if: inputs.target == 'latest'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
@@ -106,7 +106,7 @@ jobs:
   integration-test-latest-mac:
     if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, model]
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: remove existing docker container
         run: |
@@ -215,7 +215,7 @@ jobs:
   integration-test-release-linux:
     if: inputs.target == 'release'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       # mono occupies port 8084 which conflicts with mgmt-backend
       - name: Stop mono service
@@ -311,7 +311,7 @@ jobs:
   integration-test-release-mac:
     if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, model]
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Set up environment
         run: |


### PR DESCRIPTION
Because

- We have to increase timeout of integration-test-latest|release workflow

This commit

- increase timeout of integration-test-latest|release workflow