### PR TITLE
ci(Makefile): fix dind image missing bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,16 +83,7 @@ endif
 
 .PHONY: latest
 latest:			## Lunch all dependent services with their latest codebase
-	@if [ "${BUILD}" = "true" ]; then make build-latest; fi
-	@if [ ! "$$(docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:latest --format='yes' 2> /dev/null)" = "yes" ]; then \
-		@docker build --progress plain \
-			--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
-			--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
-			--build-arg K6_VERSION=${K6_VERSION} \
-			--build-arg CACHE_DATE="$(shell date)" \
-			--target latest \
-			-t ${CONTAINER_COMPOSE_IMAGE_NAME}:latest .; \
-	fi
+	@make build-latest
 	@if ! docker compose ls -q | grep -q "instill-core"; then \
 		export TMP_CONFIG_DIR=$(shell mktemp -d) && \
 		export SYSTEM_CONFIG_PATH=$(shell eval echo ${SYSTEM_CONFIG_PATH}) && \

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ endif
 
 UNAME_S := $(shell uname -s)
 
+INSTILL_MODEL_VERSION := $(shell git tag --sort=committerdate | grep -E '[0-9]' | tail -1 | cut -b 2-)
+
 CONTAINER_BUILD_NAME := model-build
 CONTAINER_COMPOSE_NAME := model-dind
 CONTAINER_COMPOSE_IMAGE_NAME := instill/model-compose
@@ -44,7 +46,7 @@ HELM_RELEASE_NAME := model
 .PHONY: all
 all:			## Launch all services with their up-to-date release version
 	@if [ "${BUILD}" = "true" ]; then make build-release; fi
-	@if [ ! "$$(docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:release --format='yes' 2> /dev/null)" = "yes" ]; then \
+	@if [ ! "$$(docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_MODEL_VERSION} --format='yes' 2> /dev/null)" = "yes" ]; then \
 		docker build --progress plain \
 			--build-arg INSTILL_CORE_VERSION=${INSTILL_CORE_VERSION} \
 			--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
@@ -54,7 +56,7 @@ all:			## Launch all services with their up-to-date release version
 			--build-arg MODEL_BACKEND_VERSION=${MODEL_BACKEND_VERSION} \
 			--build-arg CONTROLLER_MODEL_VERSION=${CONTROLLER_MODEL_VERSION} \
 			--target release \
-			-t ${CONTAINER_COMPOSE_IMAGE_NAME}:release .; \
+			-t ${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_MODEL_VERSION} .; \
 	fi
 	@if ! docker compose ls -q | grep -q "instill-core"; then \
 		export TMP_CONFIG_DIR=$(shell mktemp -d) && \
@@ -65,7 +67,7 @@ all:			## Launch all services with their up-to-date release version
 			-v $${SYSTEM_CONFIG_PATH}:$${SYSTEM_CONFIG_PATH} \
 			-e BUILD=${BUILD} \
 			--name ${CONTAINER_COMPOSE_NAME}-release \
-			${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+			${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_MODEL_VERSION} /bin/sh -c " \
 				cp /instill-ai/core/.env $${TMP_CONFIG_DIR}/.env && \
 				cp /instill-ai/core/docker-compose.build.yml $${TMP_CONFIG_DIR}/docker-compose.build.yml && \
 				cp -r /instill-ai/core/configs/influxdb $${TMP_CONFIG_DIR} && \
@@ -159,11 +161,11 @@ down:			## Stop all services and remove all service containers and volumes
 					/bin/sh -c 'cd /instill-ai/core && make down'; \
 				fi \
 			"; \
-	elif [ "$$(docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:release --format='yes' 2> /dev/null)" = "yes" ]; then \
+	elif [ "$$(docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_MODEL_VERSION} --format='yes' 2> /dev/null)" = "yes" ]; then \
 		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			--name ${CONTAINER_COMPOSE_NAME} \
-			${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+			${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_MODEL_VERSION} /bin/sh -c " \
 				if [ \"$$( docker container inspect -f '{{.State.Status}}' core-dind 2>/dev/null)\" != \"running\" ]; then \
 					/bin/sh -c 'cd /instill-ai/core && make down'; \
 				fi \
@@ -213,13 +215,13 @@ build-release:				## Build release images for all model components
 		--build-arg MODEL_BACKEND_VERSION=${MODEL_BACKEND_VERSION} \
 		--build-arg CONTROLLER_MODEL_VERSION=${CONTROLLER_MODEL_VERSION} \
 		--target release \
-		-t ${CONTAINER_COMPOSE_IMAGE_NAME}:release .
+		-t ${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_MODEL_VERSION} .
 	@docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v ${BUILD_CONFIG_DIR_PATH}/.env:/instill-ai/model/.env \
 		-v ${BUILD_CONFIG_DIR_PATH}/docker-compose.build.yml:/instill-ai/model/docker-compose.build.yml \
 		--name ${CONTAINER_BUILD_NAME}-release \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+		${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_MODEL_VERSION} /bin/sh -c " \
 			MODEL_BACKEND_VERSION=${MODEL_BACKEND_VERSION} \
 			CONTROLLER_MODEL_VERSION=${CONTROLLER_MODEL_VERSION} \
 			docker compose -f docker-compose.build.yml build --progress plain \
@@ -243,7 +245,7 @@ integration-test-release:			## Run integration test on the release model
 	@docker run --rm \
 		--network instill-network \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-release \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+		${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_MODEL_VERSION} /bin/sh -c " \
 			/bin/sh -c 'cd model-backend && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' && \
 			/bin/sh -c 'cd controller-model && make integration-test API_GATEWAY_URL=${API_GATEWAY_HOST}:${API_GATEWAY_PORT}' \
 		"
@@ -318,7 +320,7 @@ helm-integration-test-release:                       ## Run integration test on 
 		-v ${HOME}/.kube/config:/root/.kube/config \
 		${DOCKER_HELM_IT_EXTRA_PARAMS} \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-release \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+		${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_MODEL_VERSION} /bin/sh -c " \
 			/bin/sh -c 'cd /instill-ai/core && \
 				export $(grep -v '^#' .env | xargs) && \
 				helm install core charts/core \
@@ -345,12 +347,12 @@ helm-integration-test-release:                       ## Run integration test on 
 	@kubectl rollout status deployment model-triton-inference-server --namespace instill-ai --timeout=180s
 	@sleep 10
 ifeq ($(UNAME_S),Darwin)
-	@docker run --rm --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-release ${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+	@docker run --rm --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-release ${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_MODEL_VERSION} /bin/sh -c " \
 			/bin/sh -c 'cd model-backend && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' && \
 			/bin/sh -c 'cd controller-model && make integration-test API_GATEWAY_URL=host.docker.internal:${API_GATEWAY_PORT}' \
 		"
 else ifeq ($(UNAME_S),Linux)
-	@docker run --rm --network host --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-release ${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+	@docker run --rm --network host --name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-helm-release ${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_MODEL_VERSION} /bin/sh -c " \
 			/bin/sh -c 'cd model-backend && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' && \
 			/bin/sh -c 'cd controller-model && make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}' \
 		"
@@ -360,7 +362,7 @@ endif
 		-v ${HOME}/.kube/config:/root/.kube/config \
 		${DOCKER_HELM_IT_EXTRA_PARAMS} \
 		--name ${CONTAINER_BACKEND_INTEGRATION_TEST_NAME}-release \
-		${CONTAINER_COMPOSE_IMAGE_NAME}:release /bin/sh -c " \
+		${CONTAINER_COMPOSE_IMAGE_NAME}:${INSTILL_MODEL_VERSION} /bin/sh -c " \
 			/bin/sh -c 'cd /instill-ai/core && helm uninstall core --namespace ${HELM_NAMESPACE}' \
 		"
 	@kubectl delete namespace ${HELM_NAMESPACE}

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,18 @@ HELM_RELEASE_NAME := model
 .PHONY: all
 all:			## Launch all services with their up-to-date release version
 	@if [ "${BUILD}" = "true" ]; then make build-release; fi
+	@if [ ! "$$(docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:release --format='yes' 2> /dev/null)" = "yes" ]; then \
+		docker build --progress plain \
+			--build-arg INSTILL_CORE_VERSION=${INSTILL_CORE_VERSION} \
+			--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
+			--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
+			--build-arg K6_VERSION=${K6_VERSION} \
+			--build-arg CACHE_DATE="$(shell date)" \
+			--build-arg MODEL_BACKEND_VERSION=${MODEL_BACKEND_VERSION} \
+			--build-arg CONTROLLER_MODEL_VERSION=${CONTROLLER_MODEL_VERSION} \
+			--target release \
+			-t ${CONTAINER_COMPOSE_IMAGE_NAME}:release .; \
+	fi
 	@if ! docker compose ls -q | grep -q "instill-core"; then \
 		export TMP_CONFIG_DIR=$(shell mktemp -d) && \
 		export SYSTEM_CONFIG_PATH=$(shell eval echo ${SYSTEM_CONFIG_PATH}) && \
@@ -72,6 +84,15 @@ endif
 .PHONY: latest
 latest:			## Lunch all dependent services with their latest codebase
 	@if [ "${BUILD}" = "true" ]; then make build-latest; fi
+	@if [ ! "$$(docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:latest --format='yes' 2> /dev/null)" = "yes" ]; then \
+		@docker build --progress plain \
+			--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
+			--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
+			--build-arg K6_VERSION=${K6_VERSION} \
+			--build-arg CACHE_DATE="$(shell date)" \
+			--target latest \
+			-t ${CONTAINER_COMPOSE_IMAGE_NAME}:latest .; \
+	fi
 	@if ! docker compose ls -q | grep -q "instill-core"; then \
 		export TMP_CONFIG_DIR=$(shell mktemp -d) && \
 		export SYSTEM_CONFIG_PATH=$(shell eval echo ${SYSTEM_CONFIG_PATH}) && \
@@ -138,7 +159,7 @@ down:			## Stop all services and remove all service containers and volumes
 	@docker rm -f ${CONTAINER_COMPOSE_NAME}-latest >/dev/null 2>&1
 	@docker rm -f ${CONTAINER_COMPOSE_NAME}-release >/dev/null 2>&1
 	@EDITION= docker compose down -v
-	@if [ "$$(docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:latest --format='yes')" = "yes" ]; then \
+	@if [ "$$(docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:latest --format='yes' 2> /dev/null)" = "yes" ]; then \
 		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			--name ${CONTAINER_COMPOSE_NAME} \
@@ -147,7 +168,7 @@ down:			## Stop all services and remove all service containers and volumes
 					/bin/sh -c 'cd /instill-ai/core && make down'; \
 				fi \
 			"; \
-	elif [ "$$(docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:release --format='yes')" = "yes" ]; then \
+	elif [ "$$(docker image inspect ${CONTAINER_COMPOSE_IMAGE_NAME}:release --format='yes' 2> /dev/null)" = "yes" ]; then \
 		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			--name ${CONTAINER_COMPOSE_NAME} \


### PR DESCRIPTION
Because

- when `instill/model-compore:release` image is not present in the local Docker Engine (i.e., launch from scratch), the launch of `core` will fail when `make all` (without `BUILD=true`)

This commit

- fix the logic by specifically using release version for the tag of `insitll/model-compose` and detecting whether the image is present or not to build.
