### PR TITLE
chore(model): update llava and llama models

### DIFF
--- a/charts/model/values.yaml
+++ b/charts/model/values.yaml
@@ -82,7 +82,7 @@ persistence:
       storageClass: ""
       subPath: ""
       accessMode: ReadWriteOnce
-      size: 80Gi
+      size: 150Gi
       annotations: {}
     condaPack:
       existingClaim: ""

--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -56,7 +56,27 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-llama2-7b-dvc",
+      "tag": "fp32-7b-hf-tf-cpu"
+    }
+  },
+  {
+    "id": "llama2-7b-chat",
+    "description": "Llama2-7b-Chat, from meta, is trained to generate text based on your prompts.",
+    "task": "TASK_TEXT_GENERATION",
+    "model_definition": "model-definitions/github",
+    "configuration": {
+      "repository": "instill-ai/model-llama2-13b-chat-dvc",
       "tag": "fp16-7b-vllm-a100"
+    }
+  },
+  {
+    "id": "llava2-7b",
+    "description": "Llava2-7b, from liuhaotian, is trained to generate text based on your prompts with miltimodal input.",
+    "task": "TASK_TEXT_GENERATION",
+    "model_definition": "model-definitions/github",
+    "configuration": {
+      "repository": "instill-ai/model-llava-13b-dvc",
+      "tag": "fp16-7b-tf-a100"
     }
   },
   {


### PR DESCRIPTION
Because:

- We are now supporting both llama-chat and llama models.

In this commit, resources are allocated as follows:

- Support for llava 7b on GPU 0
- Support for mistral 7b on GPU 0
- Support for llama-chat 7b on GPU 1
- Support for mpt 7b on GPU 1
- Moving llama 7b to CPU mode