### PR TITLE
chore(ray): add ray-conda volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ networks:
 volumes:
   conda_pack:
     name: conda-pack
+  ray_conda:
+    name: ray-conda
   model_repository:
     name: model-repository
   model_cache:
@@ -94,6 +96,7 @@ services:
     volumes:
       - model_repository:/model-repository
       - model_cache:/.cache
+      - ray_conda:/ray-conda
     healthcheck:
       test:
         [
@@ -178,6 +181,7 @@ services:
       tail -f /dev/null'
     volumes:
       - model_repository:/model-repository
+      - ray_conda:/ray-conda
     healthcheck:
       test: ["CMD", "ray", "status"]
       timeout: 20s


### PR DESCRIPTION
Because

- avoid installing duplicate packages in `model-backend` and `ray-server`

This commit

- add volume to share python environment
