### PR TITLE
chore(ray-service): update permission for ray-conda volume

### DIFF
--- a/charts/model/templates/ray-service/ray-service.yaml
+++ b/charts/model/templates/ray-service/ray-service.yaml
@@ -173,6 +173,7 @@ data:
         fi
     done
 
+    sudo chown -R 1000:100 /ray-conda-pack
     cp -r /home/ray/anaconda3/* /ray-conda-pack
 
     echo "INFO: Conda env copying done"


### PR DESCRIPTION
Because

- We have to update permission for ray-conda volume

This commit

-  update permission for ray-conda volume
