### PR TITLE
chore(helm,ray): add wait for ray

### DIFF
--- a/charts/model/templates/model-backend/deployment.yaml
+++ b/charts/model/templates/model-backend/deployment.yaml
@@ -122,6 +122,17 @@ spec:
               value: "{{ template "model.triton" . }}"
             - name: TRITON_SERVER_HTTP_PORT
               value: "{{ template "model.triton.httpPort" . }}"
+        - name: wait-for-ray-server
+          image: curlimages/curl:8.00.1
+          command: ['sh', '-c']
+          args:
+          - >
+            while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${RAY_SERVER_HOST}:${RAY_SERVER_SERVE_PORT}/-/routes)" != "200" ]]; do echo waiting for ray-server; sleep 1; done
+          env:
+            - name: RAY_SERVER_HOST
+              value: "{{ template "model.ray" . }}"
+            - name: RAY_SERVER_SERVE_PORT
+              value: "{{ template "model.ray.servePort" . }}"
         - name: chmod-model-repostiroy
           securityContext:
             runAsUser: 0


### PR DESCRIPTION
Because

- avoid deploying models before ray-head is ready

This commit

- add wait-for-ray init-container
