### PR TITLE
chore(helm): add rolling update strategy

### DIFF
--- a/charts/model/templates/controller-model/deployment.yaml
+++ b/charts/model/templates/controller-model/deployment.yaml
@@ -10,7 +10,11 @@ metadata:
 spec:
   strategy:
     type: {{ .Values.updateStrategy.type }}
-    {{- if eq .Values.updateStrategy.type "Recreate" }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.updateStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- else}}
     rollingUpdate: null
     {{- end }}
   {{- if not .Values.controllerModel.autoscaling.enabled }}

--- a/charts/model/templates/model-backend/deployment.yaml
+++ b/charts/model/templates/model-backend/deployment.yaml
@@ -15,7 +15,11 @@ metadata:
 spec:
   strategy:
     type: {{ .Values.updateStrategy.type }}
-    {{- if eq .Values.updateStrategy.type "Recreate" }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.updateStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- else}}
     rollingUpdate: null
     {{- end }}
   {{- if not .Values.modelBackend.autoscaling.enabled }}

--- a/charts/model/templates/triton/deployment.yaml
+++ b/charts/model/templates/triton/deployment.yaml
@@ -10,7 +10,11 @@ metadata:
 spec:
   strategy:
     type: {{ .Values.updateStrategy.type }}
-    {{- if eq .Values.updateStrategy.type "Recreate" }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.updateStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- else}}
     rollingUpdate: null
     {{- end }}
   {{- if not .Values.triton.autoscaling.enabled }}

--- a/charts/model/values.yaml
+++ b/charts/model/values.yaml
@@ -8,6 +8,9 @@ fullnameOverride: ""
 # Set it as "Recreate" when "RWM" for volumes isn't supported
 updateStrategy:
   type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
 # -- Logging level: debug, info, warning, error or fatal
 logLevel: info
 # -- Enable development mode


### PR DESCRIPTION
Because

- we need to add the maxSurge and maxUnavailable values into the deployment

This commit

- add rolling update strategy
