### PR TITLE
chore(model): update triton server supported model in upcoming released

### DIFF
--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -56,7 +56,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-llama2-7b-dvc",
-      "tag": "fp32-7b-hf-tf-cpu-v2"
+      "tag": "fp32-7b-hf-tf-cpu-v2-dvc2_34"
     }
   },
   {
@@ -66,7 +66,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-llama2-7b-chat-dvc",
-      "tag": "fp16-7b-vllm-gpu0-a100"
+      "tag": "fp16-7b-vllm-gpu0-a100-dvc2_34"
     }
   },
   {
@@ -76,7 +76,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-llava-7b-dvc",
-      "tag": "fp16-7b-tf-gpu0-a100"
+      "tag": "fp16-7b-tf-gpu0-a100-dvc2_34"
     }
   },
   {
@@ -86,7 +86,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-zephyr-7b-dvc",
-      "tag": "fp32-cpu"
+      "tag": "fp32-cpu-dvc2_30"
     }
   },
   {
@@ -96,7 +96,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-diffusion-xl-dvc",
-      "tag": "fp16-gpu1-a100"
+      "tag": "fp16-gpu1-a100-dvc2_30"
     }
   },
   {
@@ -106,7 +106,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-controlnet-dvc",
-      "tag": "fp16-gpu1-a100"
+      "tag": "fp16-gpu1-a100-dvc2_30"
     }
   }
 ]

--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -56,47 +56,57 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-llama2-7b-dvc",
-      "tag": "fp32-7b-hf-tf-cpu"
+      "tag": "fp32-7b-hf-tf-cpu-v2"
     }
   },
   {
     "id": "llama2-7b-chat",
     "description": "Llama2-7b-Chat, from meta, is trained to generate text based on your prompts.",
-    "task": "TASK_TEXT_GENERATION",
+    "task": "TASK_TEXT_GENERATION_CHAT",
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-llama2-7b-chat-dvc",
-      "tag": "fp16-7b-vllm-a100"
+      "tag": "fp16-7b-vllm-gpu0-a100"
     }
   },
   {
     "id": "llava-7b",
     "description": "LLaVa-7b, from liuhaotian, is trained to generate text based on your prompts with miltimodal input.",
-    "task": "TASK_TEXT_GENERATION",
+    "task": "TASK_VISUAL_QUESTION_ANSWERING",
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-llava-7b-dvc",
-      "tag": "fp16-7b-tf-a100"
+      "tag": "fp16-7b-tf-gpu0-a100"
     }
   },
   {
-    "id": "mpt-7b",
-    "description": "Mpt-7b, from mosaicml, is trained to generate text based on your prompts.",
-    "task": "TASK_TEXT_GENERATION",
+    "id": "zephyr-7b",
+    "description": "Zephyr-7b, from Huggingface, is trained to generate text based on your prompts.",
+    "task": "TASK_TEXT_GENERATION_CHAT",
     "model_definition": "model-definitions/github",
     "configuration": {
-      "repository": "instill-ai/model-mpt-7b-dvc",
-      "tag": "fp16-7b-vllm-a100"
+      "repository": "instill-ai/model-zephyr-7b-dvc",
+      "tag": "fp32-cpu"
     }
   },
   {
-    "id": "mistral-7b",
-    "description": "Mistral-7b, from mistralai, is trained to generate text based on your prompts.",
-    "task": "TASK_TEXT_GENERATION",
+    "id": "stable-diffusion-xl",
+    "description": "Stable-Diffusion-XL, from StabilityAI, is trained to generate image based on your prompts.",
+    "task": "TASK_TEXT_TO_IMAGE",
     "model_definition": "model-definitions/github",
     "configuration": {
-      "repository": "instill-ai/model-mistral-7b-dvc",
-      "tag": "fp16-7b-vllm-a100"
+      "repository": "instill-ai/model-diffusion-xl-dvc",
+      "tag": "fp16-gpu1-a100"
+    }
+  },
+  {
+    "id": "controlnet-canny",
+    "description": "ControlNet-Canny Version, from Lvmin, is trained to generate image based on your prompts and images.",
+    "task": "TASK_IMAGE_TO_IMAGE",
+    "model_definition": "model-definitions/github",
+    "configuration": {
+      "repository": "instill-ai/model-controlnet-dvc",
+      "tag": "fp16-gpu1-a100"
     }
   }
 ]

--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -6,7 +6,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-mobilenetv2-dvc",
-      "tag": "v1.0-ray-gpu"
+      "tag": "v1.1-ray-gpu"
     }
   },
   {
@@ -16,7 +16,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-yolov7-dvc",
-      "tag": "v1.0-ray-gpu"
+      "tag": "v1.1-ray-gpu"
     }
   },
   {
@@ -36,7 +36,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-stomata-instance-segmentation-dvc",
-      "tag": "yolov7-mask-ray-gpu"
+      "tag": "v1.0-yolov7-mask-ray-gpu"
     }
   },
   {


### PR DESCRIPTION
Because

- to support models in the upcoming release

This commit

- update DVC version of some models and modify some tasks name based on INS-2574
- to support models in 2 A100 GPU, we temporary remove mistral-7b and mpt-7b
