### PR TITLE
ci(workflows): disable integration test on MacOS

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -119,7 +119,8 @@ jobs:
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
   helm-integration-test-latest-mac:
-    if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
+    if: false
+    # if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, model]
     timeout-minutes: 30
     steps:
@@ -356,7 +357,8 @@ jobs:
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
   helm-integration-test-release-mac:
-    if: inputs.target == 'release'
+    if: false
+    # if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, model]
     timeout-minutes: 30
     steps:

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -105,7 +105,8 @@ jobs:
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
   integration-test-latest-mac:
-    if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
+    if: false
+    # if: inputs.target == 'latest' && github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macOS, model]
     timeout-minutes: 20
     steps:
@@ -319,7 +320,8 @@ jobs:
           make integration-test API_GATEWAY_URL=localhost:${API_GATEWAY_PORT}
 
   integration-test-release-mac:
-    if: inputs.target == 'release'
+    if: false
+    # if: inputs.target == 'release'
     runs-on: [self-hosted, macOS, model]
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
Because

- The tests running on MacOS are not robust in current CI environment,
we decided to disable it temporally and will come back to this problem
soon.

This commit

- disable integration test on MacOS