### PR TITLE
fix(model): update llava model tag for initilization issue fix

### DIFF
--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -76,7 +76,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-llava-7b-dvc",
-      "tag": "fp16-7b-tf-gpu0-a100-dvc2_34-hotfix1"
+      "tag": "fp16-7b-tf-gpu0-a100-dvc2_34-hotfix2"
     }
   },
   {


### PR DESCRIPTION
Because

- the Llava model met value error on initialization 

This commit

- update the Llava model tag to resolve the issue (which was caused by the update of the transformers library), [reference PR](https://github.com/instill-ai/model-llava-7b-dvc/commit/5745c41a7f9cc61e35907dbb86950f616303b342)
