### PR TITLE
chore(triton): update readiness probe for triton-inference-server

### DIFF
--- a/charts/model/templates/triton/deployment.yaml
+++ b/charts/model/templates/triton/deployment.yaml
@@ -79,8 +79,8 @@ spec:
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
             initialDelaySeconds: 5
-            failureThreshold: 1
-            periodSeconds: 10
+            failureThreshold: 3
+            periodSeconds: 5
           {{- if .Values.triton.gpu.enabled }}
           resources:
             limits:

--- a/charts/model/templates/triton/deployment.yaml
+++ b/charts/model/templates/triton/deployment.yaml
@@ -70,8 +70,8 @@ spec:
               path: /v2/health/live
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
-            initialDelaySeconds: 5
-            failureThreshold: 1
+            initialDelaySeconds: 15
+            failureThreshold: 3
             periodSeconds: 10
           readinessProbe:
             httpGet:


### PR DESCRIPTION
Because

- We have to update the readiness probe timeout for triton-inference-server

This commit

- update readiness probe for triton-inference-server