### PR TITLE
chore(helm): add github pat config

### DIFF
--- a/charts/model/templates/model-backend/configmap.yaml
+++ b/charts/model/templates/model-backend/configmap.yaml
@@ -26,6 +26,9 @@ data:
         cert: /etc/instill-ai/model/ssl/model/tls.crt
         key: /etc/instill-ai/model/ssl/model/tls.key
       {{- end }}
+    github:
+      patenabled: {{ .Values.modelBackend.github.patenabled }}
+      pat: {{ .Values.modelBackend.github.pat }}
     log:
       external: {{ .Values.tags.observability }}
       otelcollector:

--- a/charts/model/values.yaml
+++ b/charts/model/values.yaml
@@ -143,6 +143,9 @@ modelBackend:
     path: https://raw.githubusercontent.com/instill-ai/model/main/model-hub/model_hub_cpu.json
   cache:
     enabled: false
+  github:
+    patenabled: false
+    pat:
   # -- Add extra env variables
   extraEnv: []
   # -- Mount external volumes


### PR DESCRIPTION
Because

- model-backend now support PAT token in config

This commit

- adopt latest model-backend config
