### PR TITLE
chore(helm): add dedicated prometheusStack flag

### DIFF
--- a/charts/model/templates/ray-service/monitor.yaml
+++ b/charts/model/templates/ray-service/monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tags.observability }}
+{{- if .Values.tags.prometheusStack }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/model/values.yaml
+++ b/charts/model/values.yaml
@@ -414,4 +414,5 @@ temporal:
     tolerations: []
     affinity: {}
 tags:
-  observability: true
+  observability: false
+  prometheusStack: false


### PR DESCRIPTION
Because

- align the observability and prometheusStack flag with `Instill Core`

This commit

- add dedicated `prometheusStack` flag
