### PR TITLE
chore(helm): adopt usage and initmodel user config

### DIFF
--- a/charts/model/values.yaml
+++ b/charts/model/values.yaml
@@ -96,6 +96,7 @@ persistence:
       annotations: {}
 # -- The usage collector configuration
 usage:
+  usageidentifieruid:
   enabled: true
   tlsenabled: true
   host: usage.instill.tech
@@ -139,6 +140,7 @@ modelBackend:
   replicaCount: 1
   # -- The model initialization configuration
   initModel:
+    ownerid: admin
     enabled: false
     path: https://raw.githubusercontent.com/instill-ai/model/main/model-hub/model_hub_cpu.json
   cache:


### PR DESCRIPTION
Because

- model-backend update usage and initmodel user to reference from config

This commit

- adopt usage and initmodel user config
