### PR TITLE
chore(model): disable console building in make-latest.yml

### DIFF
--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -2,11 +2,6 @@ name: Make Latest
 
 on:
   workflow_dispatch:
-    inputs:
-      disableConsoleBuild:
-        description: 'Disable console'
-        required: true
-        default: "true"
   pull_request:
   push:
     branches:
@@ -68,12 +63,7 @@ jobs:
           envFile: .env
 
       - name: Launch Instill Model (latest)
-        run: |
-           if "${{ github.event.inputs.disableConsoleBuild }}"; then
-             make latest BUILD=true PROFILE=console EDITION=local-ce:test
-           else
-             make latest BUILD=true PROFILE=all EDITION=local-ce:test
-           fi
+        run: make latest PROFILE=console EDITION=local-ce:test
    
       - name: List all docker containers
         run: |

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -11,6 +11,10 @@ services:
         K6_VERSION: ${K6_VERSION}
         UBUNTU_VERSION: ${UBUNTU_VERSION}
         ARTIVC_VERSION: ${ARTIVC_VERSION}
+    profiles:
+      - all
+      - controller-model
+      - console
 
   controller_model:
     image: ${CONTROLLER_MODEL_IMAGE}:${CONTROLLER_MODEL_VERSION}
@@ -20,3 +24,7 @@ services:
         SERVICE_NAME: ${CONTROLLER_MODEL_HOST}
         GOLANG_VERSION: ${GOLANG_VERSION}
         K6_VERSION: ${K6_VERSION}
+    profiles:
+      - all
+      - controller-model
+      - console

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -26,5 +26,5 @@ services:
         K6_VERSION: ${K6_VERSION}
     profiles:
       - all
-      - controller-model
+      - model
       - console


### PR DESCRIPTION
Because

- We have to disable console building in make-latest.yml file due to consuming lot of time.

This commit

- Disable console building in make-latest.yml
