### PR TITLE
ci(core): fix make build-latest PROFILE

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,7 +46,7 @@ The env variable `PROFILE` is intended to specify which service component you wa
 
 - `all`
 
-  When you set `PROFILE=all`, the whole `Instill Core` and `Instill Model` stack will be launched, meaning you want to test the system as a whole
+  When you set `PROFILE=all`, the whole `Instill Core` and `Instill Model` stack will be launched, meaning you want to test the system as a whole.
 
 - `{service}`
 

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/core/v1beta/health/mgmt
           curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:8080/model/v1alpha/health/model
+          curl -s -o /dev/null -w ''%{http_code}'\n' http://localhost:3086/v1alpha/health/controller
 
       - name: Tear down Instill Model (release)
         run: |

--- a/.github/workflows/make-latest.yml
+++ b/.github/workflows/make-latest.yml
@@ -63,8 +63,9 @@ jobs:
           envFile: .env
 
       - name: Launch Instill Model (latest)
-        run: make latest PROFILE=exclude-console EDITION=local-ce:test
-   
+        run: |
+          make latest PROFILE=exclude-console EDITION=local-ce:test
+
       - name: List all docker containers
         run: |
           docker ps -a

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -2,6 +2,13 @@ version: "3.9"
 
 services:
   model_backend:
+    profiles:
+      - all
+      - exclude-api-gateway
+      - exclude-mgmt
+      - exclude-console
+      - exclude-pipeline
+      - exclude-controller-model
     image: ${MODEL_BACKEND_IMAGE}:${MODEL_BACKEND_VERSION}
     build:
       context: ./${MODEL_BACKEND_HOST}
@@ -11,12 +18,15 @@ services:
         K6_VERSION: ${K6_VERSION}
         UBUNTU_VERSION: ${UBUNTU_VERSION}
         ARTIVC_VERSION: ${ARTIVC_VERSION}
-    profiles:
-      - all
-      - exclude-controller-model
-      - exclude-console
 
   controller_model:
+    profiles:
+      - all
+      - exclude-api-gateway
+      - exclude-mgmt
+      - exclude-console
+      - exclude-pipeline
+      - exclude-model
     image: ${CONTROLLER_MODEL_IMAGE}:${CONTROLLER_MODEL_VERSION}
     build:
       context: ./${CONTROLLER_MODEL_HOST}
@@ -24,7 +34,3 @@ services:
         SERVICE_NAME: ${CONTROLLER_MODEL_HOST}
         GOLANG_VERSION: ${GOLANG_VERSION}
         K6_VERSION: ${K6_VERSION}
-    profiles:
-      - all
-      - exclude-model
-      - exclude-console

--- a/docker-compose.latest.yml
+++ b/docker-compose.latest.yml
@@ -4,22 +4,31 @@ services:
   model_backend_migrate:
     profiles:
       - all
-      - exclude-controller-model
+      - exclude-api-gateway
+      - exclude-mgmt
       - exclude-console
+      - exclude-pipeline
+      - exclude-controller-model
     image: ${MODEL_BACKEND_IMAGE}:latest
 
   model_backend_init:
     profiles:
       - all
-      - exclude-controller-model
+      - exclude-api-gateway
+      - exclude-mgmt
       - exclude-console
+      - exclude-pipeline
+      - exclude-controller-model
     image: ${MODEL_BACKEND_IMAGE}:latest
 
   model_backend_worker:
     profiles:
       - all
-      - exclude-controller-model
+      - exclude-api-gateway
+      - exclude-mgmt
       - exclude-console
+      - exclude-pipeline
+      - exclude-controller-model
     image: ${MODEL_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
@@ -27,8 +36,11 @@ services:
   model_backend:
     profiles:
       - all
-      - exclude-controller-model
+      - exclude-api-gateway
+      - exclude-mgmt
       - exclude-console
+      - exclude-pipeline
+      - exclude-controller-model
     image: ${MODEL_BACKEND_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"
@@ -40,8 +52,11 @@ services:
   model_backend_init_model:
     profiles:
       - all
-      - exclude-controller-model
+      - exclude-api-gateway
+      - exclude-mgmt
       - exclude-console
+      - exclude-pipeline
+      - exclude-controller-model
     image: ${MODEL_BACKEND_IMAGE}:latest
     environment:
       CFG_INITMODEL_ENABLED: ${INITMODEL_ENABLED}
@@ -50,8 +65,11 @@ services:
   controller_model:
     profiles:
       - all
-      - exclude-model
+      - exclude-api-gateway
+      - exclude-mgmt
       - exclude-console
+      - exclude-pipeline
+      - exclude-model
     image: ${CONTROLLER_MODEL_IMAGE}:latest
     environment:
       CFG_SERVER_DEBUG: "true"


### PR DESCRIPTION
Because

- the `profile` in Docker Compose is used to launch or build components when `make latest` and `make build-latest`

This commit

- fix the logic