### PR TITLE
feat(model): update model-cloud serving tag to 0.8.0

### DIFF
--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -56,7 +56,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-llama2-7b-dvc",
-      "tag": "fp32-cpu-transormer_triton-v0.7.0"
+      "tag": "f32-cpu-transformer-ray-v0.8.0"
     }
   },
   {

--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -66,7 +66,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-llama2-7b-chat-dvc",
-      "tag": "f16-a100gpu-vLLM-triton-v0.7.0"
+      "tag": "f16-gpuAuto-transformer-ray-v0.8.0"
     }
   },
   {
@@ -76,7 +76,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-llava-7b-dvc",
-      "tag": "f16-a100gpu-transformer-triton-v0.7.0"
+      "tag": "f16-gpuAuto-transformer-ray-v0.8.0"
     }
   },
   {
@@ -86,7 +86,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-zephyr-7b-dvc",
-      "tag": "fp32-cpu-transormer_triton-v0.7.0-hotfix1"
+      "tag": "f32-cpu-transformer-ray-v0.8.0"
     }
   },
   {
@@ -96,7 +96,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-diffusion-xl-dvc",
-      "tag": "fp16-gpu1-a100-dvc2_30"
+      "tag": "f16-gpuAuto-diffusers-ray-v0.8.0"
     }
   },
   {
@@ -106,7 +106,7 @@
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-controlnet-dvc",
-      "tag": "fp16-gpu1-a100-dvc2_30"
+      "tag": "f16-gpuAuto-diffusers-ray-v0.8.0"
     }
   }
 ]


### PR DESCRIPTION
Because

we are transitioning the majority of our models to be served via Ray, moving away from Triton.

This commit

**Models Transitioned to Ray Serving:**
- LLaMA2-7B
- LLaMA2-7B-Chat
- LLaVA-7B
- Zephyr-7B
- Stable Diffusion XL
- ControlNet-Canny

**Models Remaining on Triton:**
- YOLOv7-Pose
- Stomata-Mask R-CNN