### PR TITLE
ci(workflows): use smaller triton image for GA test

### DIFF
--- a/.github/workflows/helm-integration-test-backend.yml
+++ b/.github/workflows/helm-integration-test-backend.yml
@@ -101,6 +101,8 @@ jobs:
             --set modelBackend.image.tag=latest \
             --set controllerModel.image.tag=latest \
             --set triton.nvidiaVisibleDevices=${NVIDIA_VISIBLE_DEVICES} \
+            --set triton.image.repository=nvcr.io/nvidia/tritonserver \
+            --set triton.image.tag=23.04-pyt-python-py3 \
             --set rayService.image.tag=latest-cpu \
             --set rayService.headGroupSpec.resources.limits.cpu=0 \
             --set rayService.headGroupSpec.resources.limits.memory=2Gi \
@@ -236,6 +238,8 @@ jobs:
             --set modelBackend.image.tag=latest \
             --set controllerModel.image.tag=latest \
             --set triton.nvidiaVisibleDevices=${NVIDIA_VISIBLE_DEVICES} \
+            --set triton.image.repository=nvcr.io/nvidia/tritonserver \
+            --set triton.image.tag=23.04-pyt-python-py3 \
             --set rayService.image.tag=latest-arm \
             --set rayService.headGroupSpec.resources.limits.cpu=0 \
             --set rayService.headGroupSpec.resources.limits.memory=2Gi \
@@ -362,6 +366,8 @@ jobs:
             --set modelBackend.image.tag=${MODEL_BACKEND_VERSION} \
             --set controllerModel.image.tag=${CONTROLLER_MODEL_VERSION} \
             --set triton.nvidiaVisibleDevices=${NVIDIA_VISIBLE_DEVICES} \
+            --set triton.image.repository=nvcr.io/nvidia/tritonserver \
+            --set triton.image.tag=23.04-pyt-python-py3 \
             --set rayService.image.tag=${RAY_SERVER_VERSION}-cpu \
             --set rayService.headGroupSpec.resources.limits.cpu=0 \
             --set rayService.headGroupSpec.resources.limits.memory=2Gi \
@@ -503,6 +509,8 @@ jobs:
             --set modelBackend.image.tag=${MODEL_BACKEND_VERSION} \
             --set controllerModel.image.tag=${CONTROLLER_MODEL_VERSION} \
             --set triton.nvidiaVisibleDevices=${NVIDIA_VISIBLE_DEVICES} \
+            --set triton.image.repository=nvcr.io/nvidia/tritonserver \
+            --set triton.image.tag=23.04-pyt-python-py3 \
             --set rayService.image.tag=${RAY_SERVER_VERSION}-arm \
             --set rayService.headGroupSpec.resources.limits.cpu=0 \
             --set rayService.headGroupSpec.resources.limits.memory=2Gi \

--- a/.github/workflows/integration-test-backend.yml
+++ b/.github/workflows/integration-test-backend.yml
@@ -91,6 +91,8 @@ jobs:
           EDITION=local-ce:test \
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          TRITON_SERVER_IMAGE=nvcr.io/nvidia/tritonserver \
+          TRITON_SERVER_VERSION=23.04-pyt-python-py3 \
           RAY_PLATFORM=cpu \
           COMPOSE_PROFILES=all \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
@@ -187,6 +189,8 @@ jobs:
           EDITION=local-ce:test \
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          TRITON_SERVER_IMAGE=nvcr.io/nvidia/tritonserver \
+          TRITON_SERVER_VERSION=23.04-pyt-python-py3 \
           RAY_PLATFORM=arm \
           COMPOSE_PROFILES=all \
           docker compose -f docker-compose.yml -f docker-compose.latest.yml up -d --quiet-pull
@@ -310,6 +314,8 @@ jobs:
           EDITION=local-ce:test \
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          TRITON_SERVER_IMAGE=nvcr.io/nvidia/tritonserver \
+          TRITON_SERVER_VERSION=23.04-pyt-python-py3 \
           RAY_PLATFORM=cpu \
           docker compose up -d --quiet-pull
           EDITION=local-ce:test \
@@ -405,6 +411,8 @@ jobs:
           EDITION=local-ce:test \
           ITMODE_ENABLED=true \
           TRITON_CONDA_ENV_PLATFORM=cpu \
+          TRITON_SERVER_IMAGE=nvcr.io/nvidia/tritonserver \
+          TRITON_SERVER_VERSION=23.04-pyt-python-py3 \
           RAY_PLATFORM=arm \
           docker compose up -d --quiet-pull
           EDITION=local-ce:test \


### PR DESCRIPTION
Because

- GA integration-test workflow will result in `no disk space`

This commit

- use official triton image with smaller footprint
