### PR TITLE
chore(model_hub): update tag and name for llava

### DIFF
--- a/model-hub/model_hub_gpu.json
+++ b/model-hub/model_hub_gpu.json
@@ -70,13 +70,13 @@
     }
   },
   {
-    "id": "llava-7b",
+    "id": "llava-1-6-7b",
     "description": "LLaVa-7b, from liuhaotian, is trained to generate text based on your prompts with miltimodal input.",
     "task": "TASK_VISUAL_QUESTION_ANSWERING",
     "model_definition": "model-definitions/github",
     "configuration": {
       "repository": "instill-ai/model-llava-7b-dvc",
-      "tag": "f16-gpuAuto-transformer-ray-v0.8.0"
+      "tag": "f16-gpuAuto-transformer-ray-v0.8.16"
     }
   },
   {


### PR DESCRIPTION
Because

- we now host llava v1.6

This commit

- update llava name and tag
